### PR TITLE
Add Docker cross-platform build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,19 @@
+name: Docker Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build with Docker
+        run: |
+          docker buildx build --platform ${{ matrix.platform }} --load -t oni-modloader:${{ matrix.platform }} .

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Source/lib/Assembly-UnityScript-firstpass.dll
 Source/lib/UnityEngine.dll
 Source/lib/UnityEngine.*.dll
 Managed/UnityEngine.*.dll
+Source/lib/JetBrains.*.dll
 *.FileListAbsolute.txt
 *.CopyComplete
 *.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Build ONI-Modloader using a Docker container
+# Supports cross-platform builds via Docker Buildx
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+
+# Install Mono and tools needed to fetch dependencies
+RUN apt-get update && apt-get install -y mono-complete curl unzip \ 
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+# Download required Unity and JetBrains dependencies
+RUN curl -L -o /tmp/UnityEngine.CoreModule.nupkg https://api.nuget.org/v3-flatcontainer/unityengine.coremodule/2020.3.1/unityengine.coremodule.2020.3.1.nupkg \ 
+    && curl -L -o /tmp/JetBrains.Annotations.nupkg https://api.nuget.org/v3-flatcontainer/jetbrains.annotations/2025.2.0/jetbrains.annotations.2025.2.0.nupkg \ 
+    && mkdir /deps \ 
+    && unzip -q /tmp/UnityEngine.CoreModule.nupkg -d /deps/core \ 
+    && unzip -q /tmp/JetBrains.Annotations.nupkg -d /deps/jetbrains \ 
+    && cp /deps/core/lib/net48/UnityEngine.CoreModule.dll Source/lib/UnityEngine.CoreModule.dll \ 
+    && cp /deps/jetbrains/lib/net20/JetBrains.Annotations.dll Source/lib/JetBrains.Annotations.dll
+
+# Build the solution using xbuild (Mono's MSBuild)
+RUN xbuild Source/ModLoader.sln

--- a/Source/ModLoader/ModLoader.csproj
+++ b/Source/ModLoader/ModLoader.csproj
@@ -44,12 +44,12 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\lib\UnityEngine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\lib\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="JetBrains.Annotations">
+      <HintPath>..\lib\JetBrains.Annotations.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -62,7 +62,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)" "Z:\Applications\Steam Games\SteamApps\common\OxygenNotIncluded\OxygenNotIncluded.app\Contents\Resources\Data\Managed" /Y
 
 rem xcopy "$(TargetDir)0harmony.dll" "Z:\Applications\Steam Games\SteamApps\common\OxygenNotIncluded\OxygenNotIncluded.app\Contents\Resources\Data\Managed" /Y


### PR DESCRIPTION
## Summary
- add Dockerfile to build project using Mono
- add GitHub Actions workflow to build with Docker for linux/amd64 and linux/arm64
- fetch Unity and JetBrains dependencies during Docker build and link JetBrains.Annotations in project

## Testing
- `xbuild Source/ModLoader.sln`
- `docker build .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_688de5913a30832784a92b7d5f899a76