### PR TITLE
Add docker compose for building mod loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ This project uses source code of and is based on: [Harmony](https://github.com/p
 **Report Bugs** for ONI-Modloader here: https://github.com/javisar/ONI-Modloader/issues
 
 
+Building with Docker Compose
+----------------------------
+This repository includes a `docker-compose.yml` file that builds the project inside a container
+and copies the compiled binaries to your host machine. Run the following command to build and
+extract the artifacts:
+
+```
+docker compose run --rm build
+```
+
+The compiled files will be available in the local `build` directory.
+
 Mods based in Harmony
 ---------------------
 * [**Javisar's Mods**](https://github.com/javisar/ONI-Modloader-Mods) [Forum](https://forums.kleientertainment.com/forums/topic/97444-mods-trevices-mods-lair/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  build:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: oni-modloader:latest
+    volumes:
+      - ./build:/output
+    command: >
+      /bin/sh -c "mkdir -p /output;
+      cp -r Source/Hook/bin/Debug/* /output/ 2>/dev/null || true;
+      cp -r Source/Injector/bin/Debug/* /output/ 2>/dev/null || true;
+      cp -r Source/ModLoader/bin/Debug/* /output/ 2>/dev/null || true;
+      cp -r Source/ModLoaderInstaller/bin/Debug/* /output/ 2>/dev/null || true"


### PR DESCRIPTION
## Summary
- add docker-compose file that copies built binaries to a host volume
- document docker compose usage to extract compiled files

## Testing
- `docker build . -t oni-modloader:latest` *(fails: Cannot connect to the Docker daemon)*
- `docker-compose config`


------
https://chatgpt.com/codex/tasks/task_e_688defbf831883279f392af272fd956e