### PR TITLE
Fix NotNull attribute alias

### DIFF
--- a/Source/ModLoader/ModLoader.cs
+++ b/Source/ModLoader/ModLoader.cs
@@ -2,6 +2,7 @@ namespace ModLoader
 {
     using Harmony;
     using JetBrains.Annotations;
+    using NotNullAttribute = JetBrains.Annotations.NotNullAttribute;
     using System;
     using System.Collections.Generic;
     using System.IO;


### PR DESCRIPTION
## Summary
- ensure `[NotNull]` attributes map to JetBrains annotations

## Testing
- `xbuild Source/ModLoader.sln` (fails: Reference 'UnityEngine.CoreModule' not resolved)


------
https://chatgpt.com/codex/tasks/task_e_688df6006fe08327af3798ad1332b29f