### PR TITLE
Resolve NotNull attribute conflicts

### DIFF
--- a/Source/ModLoader/ModLoader.cs
+++ b/Source/ModLoader/ModLoader.cs
@@ -1,8 +1,7 @@
 namespace ModLoader
 {
     using Harmony;
-    using JetBrains.Annotations;
-    using NotNullAttribute = JetBrains.Annotations.NotNullAttribute;
+    using JetBrainsNotNull = JetBrains.Annotations.NotNullAttribute;
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -148,7 +147,7 @@ namespace ModLoader
             return false;
         }
 
-        private static List<Assembly> ApplyHarmonyPatches([NotNull] List<Assembly> modAssemblies)
+        private static List<Assembly> ApplyHarmonyPatches([JetBrainsNotNull] List<Assembly> modAssemblies)
         {
             ModLogger.WriteLine("Applying Harmony patches");
             List<string> failedMods = new List<string>();
@@ -193,7 +192,7 @@ namespace ModLoader
             return loadedMods;
         }
 
-        private static void CallOnLoadMethods([NotNull] List<Assembly> modAssemblies)
+        private static void CallOnLoadMethods([JetBrainsNotNull] List<Assembly> modAssemblies)
         {
             ModLogger.WriteLine("Calling OnLoad methods");
 
@@ -233,7 +232,7 @@ namespace ModLoader
             }
         }
 
-        private static string ExceptionToString([NotNull] Exception ex)
+        private static string ExceptionToString([JetBrainsNotNull] Exception ex)
         {
             return " - " + ex.GetType().Name + ": " + ex.Message;
         }
@@ -336,7 +335,7 @@ namespace ModLoader
         {
         }
 
-        private static string BuildMessage(string baseMessage, [NotNull] List<string> mods)
+        private static string BuildMessage(string baseMessage, [JetBrainsNotNull] List<string> mods)
         {
             return baseMessage + "\n" + string.Join("\n", mods.ToArray());
         }

--- a/Source/ModLoader/ModLoader.csproj
+++ b/Source/ModLoader/ModLoader.csproj
@@ -48,10 +48,6 @@
       <HintPath>..\lib\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="JetBrains.Annotations">
-      <HintPath>..\lib\JetBrains.Annotations.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Activator.cs" />


### PR DESCRIPTION
## Summary
- Alias JetBrains NotNull attribute to avoid UnityEngine conflict
- Remove JetBrains.Annotations reference from project

## Testing
- `bash libref_download.sh`
- `xbuild Source/ModLoader.sln`


------
https://chatgpt.com/codex/tasks/task_e_688df710d19483278cd7c80666dde5fb